### PR TITLE
[SQUASHED]config: adblock setup

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -202,6 +202,13 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
     system/%/libfuse-lite.so \
     system/%/libntfs-3g.so
 
+# Adblock
+PRODUCT_PACKAGES += \
+    hosts.adblock
+
+PRODUCT_COPY_FILES += \
+    vendor/pixelstar/etc/init/init.adblock.rc:$(TARGET_COPY_OUT_SYSTEM_EXT)/etc/init/init.adblock.rc
+
 ## neofetch
 PRODUCT_COPY_FILES += \
     vendor/pixelstar/tools/neofetch:$(TARGET_COPY_OUT_SYSTEM_EXT)/bin/neofetch

--- a/etc/Android.bp
+++ b/etc/Android.bp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 The LeafOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+genrule {
+    name: "gen_hosts.adblock",
+    srcs: ["hosts.adblock.in"],
+    out: ["hosts.adblock"],
+    cmd: "cat system/core/rootdir/etc/hosts $(in) > $(out)"
+}
+
+prebuilt_etc {
+    name: "hosts.adblock",
+    src: ":gen_hosts.adblock",
+    system_ext_specific: true,
+}

--- a/etc/Android.mk
+++ b/etc/Android.mk
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2023 The LeafOS Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+HOSTS_ADBLOCK := $(TARGET_OUT_ETC)/hosts.adblock
+$(HOSTS_ADBLOCK): $(LOCAL_INSTALLED_MODULE)
+	@mkdir -p $(dir $@)
+	@rm -rf $@
+	$(hide) cp system/core/rootdir/etc/hosts $@
+
+HOSTS_ADBLOCK_SYMLINK := $(TARGET_OUT_ETC)/hosts
+$(HOSTS_ADBLOCK_SYMLINK): $(LOCAL_INSTALLED_MODULE) $(HOSTS_ADBLOCK)
+	@mkdir -p $(dir $@)
+	@rm -rf $@
+	$(hide) ln -sf hosts.adblock $@
+
+ALL_DEFAULT_INSTALLED_MODULES += $(HOSTS_ADBLOCK_SYMLINK)
+
+include $(call all-makefiles-under,$(LOCAL_PATH))

--- a/etc/init/init.adblock.rc
+++ b/etc/init/init.adblock.rc
@@ -1,0 +1,8 @@
+on property:persist.sys.adblock_enabled=true
+    setprop sys.adblock_status started
+
+on property:sys.adblock_status=started
+    mount none /system_ext/etc/hosts.adblock /system/etc/hosts.adblock bind
+
+on property:sys.adblock_status=stopped
+    umount /system/etc/hosts.adblock


### PR DESCRIPTION
Change-Id: I9574f5f56ba58ba604c9da84e56080a6e528832b
Signed-off-by: darknius20 <darknius21@gmail.com>

config: Workaround for safetynet with adblock enabled

* It seems to specifically check for /system/hosts bind mounts, making hosts a symlink to hosts.adblock and bind mounting to that path instead bypasses it.

Change-Id: I1ed3ef2abde90fb5e1d91f396e24ef8a8762dcd7

f